### PR TITLE
Update ctranslate2 install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,11 +86,12 @@
 在新開的 Kaggle Notebook 中，執行以下命令來安裝 `faster-whisper` 套件：(約20秒)
 #### 2024/10/26**更新**:ctranslate2最新版在cuda相容性上貌似出現問題，目前以退回版本方式處理
 #### 2024/12/11**更新**:~FW1.1.0版本中問題似乎已經解決，可以拿掉ctranslate2==4.4.0。~
-#### 2025/04/22**更新**:FW1.1.1版本下問題受限於平台環境的依賴版本，目前仍需ctranslate2==4.4.0。 **[註]**:平台環境目前不穩定，建議回滾到去年以前的環境或等更新
+#### 2025/04/22**更新**:~FW1.1.1版本下問題受限於平台環境的依賴版本，目前仍需ctranslate2==4.4.0。 **[註]**:平台環境目前不穩定，建議回滾到去年以前的環境或等更新~
+#### 2025/06/30**更新**:`ctranslate2` 已升級至 4.6.0，並隨 `faster-whisper==1.1.1` 一併安裝，相關 CUDA 相容性問題已解決，無需再額外安裝 `ctranslate2==4.4.0`。
 
 ```python
-!pip install faster-whisper==1.1.1 ctranslate2==4.4.0 -q
-# 使用 -q 安靜模式安裝
+# 安裝 faster-whisper (已內含 ctranslate2 4.6.0)
+!pip install faster-whisper==1.1.1 -q
 ```
 
 #### 2. 上傳模型至 Kaggle，並在notebook中加載
@@ -454,12 +455,12 @@ merge_transcriptions("01.txt", "02.txt", "merged_output.txt")
 In a new Kaggle Notebook, execute the following command to install the `faster-whisper` package (takes about 20 seconds):
 #### 2024/10/26 **Update**: The latest version of `ctranslate2` seems to have CUDA compatibility issues. Currently handled by reverting to an older version.
 #### 2024/12/11 **Update**: ~~Issue seems resolved in FW1.1.0, `ctranslate2==4.4.0` might be removable.~~
-#### 2025/04/22 **Update**: Under FW1.1.1, due to platform environment dependency versions, `ctranslate2==4.4.0` is still required. **[Note]**: The platform environment is currently unstable; reverting to an environment from last year or waiting for updates is recommended.
+#### 2025/04/22 **Update**: ~~Under FW1.1.1, due to platform environment dependency versions, `ctranslate2==4.4.0` is still required. **[Note]**: The platform environment is currently unstable; reverting to an environment from last year or waiting for updates is recommended.~~
+#### 2025/06/30 **Update**: `ctranslate2` has been upgraded to 4.6.0 and is bundled with `faster-whisper==1.1.1`. The previous compatibility issue has been resolved, so you no longer need to install `ctranslate2==4.4.0` separately.
 
 ```python
-# Install faster-whisper and pin ctranslate2 version for compatibility
-!pip install faster-whisper==1.1.1 ctranslate2==4.4.0 -q
-# Use -q for quiet installation
+# Install faster-whisper (includes ctranslate2 4.6.0)
+!pip install faster-whisper==1.1.1 -q
 ```
 
 #### 2. Upload the Model to Kaggle and Load it in the Notebook


### PR DESCRIPTION
## Summary
- clarify that faster-whisper 1.1.1 already bundles ctranslate2 4.6.0
- remove old install command for ctranslate2 4.4.0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5e209b24832783ba363c448671cd